### PR TITLE
[BUGFIX] Fix namespace problem causing autoloader to fail

### DIFF
--- a/Classes/Domain/Model/AbstractModel.php
+++ b/Classes/Domain/Model/AbstractModel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace FRUIT\GoogleServices\Domain\Model\Node;
+namespace FRUIT\GoogleServices\Domain\Model;
 
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 

--- a/Classes/Domain/Model/Node.php
+++ b/Classes/Domain/Model/Node.php
@@ -26,7 +26,6 @@
 
 namespace FRUIT\GoogleServices\Domain\Model;
 
-use FRUIT\GoogleServices\Domain\Model\Node\AbstractModel;
 use FRUIT\GoogleServices\Domain\Model\Node\Geo;
 use FRUIT\GoogleServices\Domain\Model\Node\Image;
 use FRUIT\GoogleServices\Domain\Model\Node\News;


### PR DESCRIPTION
I think there's a little mixup as the namespace of the AbstractModel doesn't match the directory structure and therefore causes the Autoloader to fail..
