### PR TITLE
[BUGFIX] ignore pages with doktype "spacer"

### DIFF
--- a/Classes/Service/SitemapProvider/Pages.php
+++ b/Classes/Service/SitemapProvider/Pages.php
@@ -85,7 +85,8 @@ class Pages implements SitemapProviderInterface
             // exclude Doctypes
             if (in_array($record['doktype'], array(
                 PageRepository::DOKTYPE_LINK,
-                PageRepository::DOKTYPE_SHORTCUT
+                PageRepository::DOKTYPE_SHORTCUT,
+                PageRepository::DOKTYPE_SPACER
             ))) {
                 continue;
             }


### PR DESCRIPTION
IMO a spacer should never be indexed by google. 
