### PR TITLE
[BUGFIX] fix rootline no_search check

### DIFF
--- a/Classes/Service/SitemapProvider/Pages.php
+++ b/Classes/Service/SitemapProvider/Pages.php
@@ -94,10 +94,11 @@ class Pages implements SitemapProviderInterface
             if ($record['fe_group'] != 0 || $record['no_search'] != 0) {
                 continue;
             }
+
             $rootLineList = $GLOBALS['TSFE']->sys_page->getRootLine($record['uid']);
             $addToNode = true;
             foreach ($rootLineList as $rootPage) {
-                if ($rootPage['extendToSubpages'] == 1 && ($rootPage['fe_group'] != 0 || $record['no_search'] != 0)) {
+                if ($rootPage['extendToSubpages'] == 1 && ($rootPage['fe_group'] != 0 || $rootPage['no_search'] != 0)) {
                     $addToNode = false;
                     break;
                 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -22,3 +22,5 @@ if (!defined('TYPO3_MODE')) {
 ));
 
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['list_type_Info']['googleservices_pisitemap'][] = 'FRUIT\\GoogleServices\\Hooks\\CmsLayout->renderSitemapPlugin';
+
+$GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ($GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] == '' ? '' : ',') . 'no_search';


### PR DESCRIPTION
to be able to take no_search flag together with extendToSubpages in rootline into account, it must be added to addRootLineFields. 
